### PR TITLE
Fix wrong results on ppc64 BE (clang).

### DIFF
--- a/clang_workaround.h
+++ b/clang_workaround.h
@@ -31,7 +31,11 @@ static inline
 __vector unsigned long long  __builtin_pack_vector (unsigned long __a,
 						    unsigned long __b)
 {
+	#if defined(__BIG_ENDIAN__)
+	__vector unsigned long long __v = {__a, __b};
+	#else
 	__vector unsigned long long __v = {__b, __a};
+	#endif
 	return __v;
 }
 
@@ -44,21 +48,34 @@ unsigned long __builtin_unpack_vector (__vector unsigned long long __v,
 	return __v[__o];
 }
 
+#if defined(__BIG_ENDIAN__)
+#define __builtin_unpack_vector_0(a) __builtin_unpack_vector ((a), 0)
+#define __builtin_unpack_vector_1(a) __builtin_unpack_vector ((a), 1)
+#else
 #define __builtin_unpack_vector_0(a) __builtin_unpack_vector ((a), 1)
 #define __builtin_unpack_vector_1(a) __builtin_unpack_vector ((a), 0)
+#endif
 
 #else
 
 static inline
 unsigned long __builtin_unpack_vector_0 (__vector unsigned long long __v)
 {
+	#if defined(__BIG_ENDIAN__)
+	return vec_xxpermdi(__v, __v, 0x0)[1];
+	#else
 	return vec_xxpermdi(__v, __v, 0x0)[0];
+	#endif
 }
 
 static inline
 unsigned long __builtin_unpack_vector_1 (__vector unsigned long long __v)
 {
+	#if defined(__BIG_ENDIAN__)
+	return vec_xxpermdi(__v, __v, 0x3)[1];
+	#else
 	return vec_xxpermdi(__v, __v, 0x3)[0];
+	#endif
 }
 #endif /* vec_xxpermdi */
 

--- a/vec_final_fold2.c
+++ b/vec_final_fold2.c
@@ -24,38 +24,12 @@
  */
 #include <altivec.h>
 
-/*
- * Those stubs fix clang incompatibilitie issues with GCC builtins.
- */
 #if defined (__clang__)
-#define __builtin_crypto_vpmsumw __builtin_crypto_vpmsumb
-#define __builtin_crypto_vpmsumd __builtin_crypto_vpmsumb
-
-__vector unsigned long long __attribute__((overloadable))
-vec_ld(int __a, const __vector unsigned long long* __b)
-{
-	return (__vector unsigned long long)__builtin_altivec_lvx(__a, __b);
-}
-
-/*
- * GCC __builtin_pack_vector_int128 returns a vector __int128_t but Clang
- * seems to not recognize this type. On GCC this builtin is translated to a
- * xxpermdi instruction that only move the registers __a, __b instead generates
- * a load. Clang doesn't have this builtin or xxpermdi intrinsics. Was recently
- * implemented https://reviews.llvm.org/rL303760.
- * */
-__vector unsigned long long  __builtin_pack_vector (unsigned long __a,
-												    unsigned long __b)
-{
-	__vector unsigned long long __v = {__a, __b};
-	return __v;
-}
-
-unsigned long __builtin_unpack_vector (__vector unsigned long long __v,
-									   int __o)
-{
-	return __v[__o];
-}
+#include "clang_workaround.h"
+#else
+#define __builtin_pack_vector(a, b)  __builtin_pack_vector_int128 ((a), (b))
+#define __builtin_unpack_vector_0(a) __builtin_unpack_vector_int128 ((vector __int128_t)(a), 0)
+#define __builtin_unpack_vector_1(a) __builtin_unpack_vector_int128 ((vector __int128_t)(a), 1)
 #endif
 
 #if defined(__LITTLE_ENDIAN__)
@@ -166,11 +140,8 @@ final_fold2(void *__restrict__ data) {
 	 * V0 [ 0 1 2 X ]
 	 * V0 [ 0 X 2 3 ]
 	 */
-#if defined (__clang__)
-	result = __builtin_unpack_vector (v0, 0);
-#else
-	result = __builtin_unpack_vector_int128 ((vector __int128_t)v0, 1);
-#endif
+	result = __builtin_unpack_vector_1 (v0);
+
 	return result;
 }
 
@@ -251,11 +222,7 @@ final_fold2_reflected(void *__restrict__ data) {
 	v0 = (__vector unsigned long long)vec_sld ((__vector unsigned char)v0,
 			(__vector unsigned char)vzero, 4);
 
-#if defined (__clang__)
-	result = __builtin_unpack_vector (v0, 1);
-#else
-	result = __builtin_unpack_vector_int128 ((vector __int128_t)v0, 0);
-#endif
+	result = __builtin_unpack_vector_0 (v0);
 
 	return result;
 }


### PR DESCRIPTION
This commit fixes the wrong results we get on ppc64 (Big Endian) for C vector
version of the code.